### PR TITLE
Added support for devastate and relevant talents

### DIFF
--- a/sim_interface/source/sim_interface.cpp
+++ b/sim_interface/source/sim_interface.cpp
@@ -212,6 +212,7 @@ std::vector<double> get_damage_sources(const Damage_sources& damage_sources_vect
         damage_sources_vector.slam_damage / total_damage,
         damage_sources_vector.mortal_strike_damage / total_damage,
         damage_sources_vector.sweeping_strikes_damage / total_damage,
+        damage_sources_vector.devastate_damage / total_damage,
     };
 }
 
@@ -872,7 +873,7 @@ Sim_output Sim_interface::simulate(const Sim_input& input)
     std::vector<std::string> damage_names = {"White MH",      "White OH",         "Bloodthirst", "Execute",
                                              "Heroic Strike", "Cleave",           "Whirlwind",   "Hamstring",
                                              "Deep Wounds",   "Item Hit Effects", "Overpower",   "Slam",
-                                             "Mortal Strike", "Sweeping Strikes", "Sword Specialization"};
+                                             "Mortal Strike", "Sweeping Strikes", "Devastate", "Sword Specialization"};//sword specialization isnt listed as a damage_source
     for (size_t i = 0; i < damage_time_lapse_raw.size(); i++)
     {
         double total_damage = 0;
@@ -1068,6 +1069,7 @@ Sim_output Sim_interface::simulate(const Sim_input& input)
         debug_topic += "DPS hamstring: " + std::to_string(dmg_dist.hamstring_damage * f) + "<br>";
         debug_topic += "DPS deep wounds: " + std::to_string(dmg_dist.deep_wounds_damage * f) + "<br>";
         debug_topic += "DPS item effects: " + std::to_string(dmg_dist.item_hit_effects_damage * f) + "<br><br>";
+        debug_topic += "DPS devastate: " + std::to_string(dmg_dist.devastate_damage * f) + "<br><br>";
 
         auto g = 1.0 / base_dps.samples();
         debug_topic += "Casts:<br>";
@@ -1085,6 +1087,7 @@ Sim_output Sim_interface::simulate(const Sim_input& input)
         debug_topic += "#Hits hamstring: " + std::to_string(dmg_dist.hamstring_count * g) + "<br>";
         debug_topic += "#Hits deep_wounds: " + std::to_string(dmg_dist.deep_wounds_count * g) + "<br>";
         debug_topic += "#Hits item effects: " + std::to_string(dmg_dist.item_hit_effects_count * g) + "<br>";
+        debug_topic += "#Hits devastate " + std::to_string(dmg_dist.devastate_damage * g) + "<br>";
     }
 
     for (auto& v : sample_std_dps_vec)

--- a/sim_interface/source/sim_interface.cpp
+++ b/sim_interface/source/sim_interface.cpp
@@ -873,7 +873,7 @@ Sim_output Sim_interface::simulate(const Sim_input& input)
     std::vector<std::string> damage_names = {"White MH",      "White OH",         "Bloodthirst", "Execute",
                                              "Heroic Strike", "Cleave",           "Whirlwind",   "Hamstring",
                                              "Deep Wounds",   "Item Hit Effects", "Overpower",   "Slam",
-                                             "Mortal Strike", "Sweeping Strikes", "Devastate", "Sword Specialization"};//sword specialization isnt listed as a damage_source
+                                             "Mortal Strike", "Sweeping Strikes", "Devastate"};
     for (size_t i = 0; i < damage_time_lapse_raw.size(); i++)
     {
         double total_damage = 0;

--- a/sim_interface/source/sim_interface.cpp
+++ b/sim_interface/source/sim_interface.cpp
@@ -1059,6 +1059,7 @@ Sim_output Sim_interface::simulate(const Sim_input& input)
         debug_topic += "DPS white OH: " + std::to_string(dmg_dist.white_oh_damage * f) + "<br>";
         debug_topic += "DPS bloodthirst: " + std::to_string(dmg_dist.bloodthirst_damage * f) + "<br>";
         debug_topic += "DPS mortal strike: " + std::to_string(dmg_dist.mortal_strike_damage * f) + "<br>";
+        debug_topic += "DPS devastate: " + std::to_string(dmg_dist.devastate_damage * f) + "<br><br>";
         debug_topic += "DPS sweeping strikes: " + std::to_string(dmg_dist.sweeping_strikes_damage * f) + "<br>";
         debug_topic += "DPS overpower: " + std::to_string(dmg_dist.overpower_damage * f) + "<br>";
         debug_topic += "DPS slam: " + std::to_string(dmg_dist.slam_damage * f) + "<br>";
@@ -1069,7 +1070,7 @@ Sim_output Sim_interface::simulate(const Sim_input& input)
         debug_topic += "DPS hamstring: " + std::to_string(dmg_dist.hamstring_damage * f) + "<br>";
         debug_topic += "DPS deep wounds: " + std::to_string(dmg_dist.deep_wounds_damage * f) + "<br>";
         debug_topic += "DPS item effects: " + std::to_string(dmg_dist.item_hit_effects_damage * f) + "<br><br>";
-        debug_topic += "DPS devastate: " + std::to_string(dmg_dist.devastate_damage * f) + "<br><br>";
+
 
         auto g = 1.0 / base_dps.samples();
         debug_topic += "Casts:<br>";

--- a/simulator/include/Combat_simulator.hpp
+++ b/simulator/include/Combat_simulator.hpp
@@ -368,6 +368,8 @@ private:
     int mortal_strike_rage_cost_{};
     int bloodthirst_rage_cost_{};
     int devastate_rage_cost_{};
+    int sunder_armor_rage_cost_{};
+    int hamstring_rage_cost_{};
     int tactical_mastery_rage_{};
 
     Special_stats flurry_{};

--- a/simulator/include/Combat_simulator.hpp
+++ b/simulator/include/Combat_simulator.hpp
@@ -229,6 +229,8 @@ public:
 
     void mortal_strike(Sim_state& state);
 
+    void devastate(Sim_state& state);
+
     void bloodthirst(Sim_state& state);
 
     void whirlwind(Sim_state& state);
@@ -365,6 +367,7 @@ private:
     int whirlwind_rage_cost_{};
     int mortal_strike_rage_cost_{};
     int bloodthirst_rage_cost_{};
+    int devastate_rage_cost_{};
     int tactical_mastery_rage_{};
 
     Special_stats flurry_{};
@@ -373,6 +376,7 @@ private:
     bool use_bloodthirst_{};
     bool use_rampage_{};
     bool use_mortal_strike_{};
+    bool use_devastate_{};
     bool use_sweeping_strikes_{};
     bool have_flurry_{};
 

--- a/simulator/include/Config.hpp
+++ b/simulator/include/Config.hpp
@@ -79,6 +79,10 @@ struct Combat_simulator_config
         bool use_ms_in_exec_phase{};
         int ms_whirlwind_cooldown_thresh{};
 
+        bool use_devastate{};
+        bool use_devastate_in_exec_phase{};
+        int devastate_whirlwind_cooldown_thresh{};
+
         bool use_whirlwind{};
         bool use_ww_in_exec_phase{};
         double whirlwind_rage_thresh{};

--- a/simulator/include/Config.tcc
+++ b/simulator/include/Config.tcc
@@ -57,6 +57,10 @@ void Combat_simulator_config::parse_combat_simulator_config(const T& input)
     combat.use_ms_in_exec_phase = String_helpers::find_string(input.options, "use_ms_in_exec_phase");
     combat.ms_whirlwind_cooldown_thresh = to_millis(fv.find("ms_whirlwind_cooldown_thresh_dd"));
 
+    combat.use_devastate = String_helpers::find_string(input.options, "use_devastate");
+    combat.use_devastate_in_exec_phase = String_helpers::find_string(input.options, "use_devastate_in_exec_phase");
+    combat.devastate_whirlwind_cooldown_thresh = to_millis(fv.find("devastate_whirlwind_cooldown_thresh_dd"));
+
     combat.use_whirlwind = String_helpers::find_string(input.options, "use_whirlwind");
     combat.use_ww_in_exec_phase = String_helpers::find_string(input.options, "use_ww_in_exec_phase");
     combat.whirlwind_rage_thresh = fv.find("whirlwind_rage_thresh_dd");

--- a/simulator/include/damage_sources.hpp
+++ b/simulator/include/damage_sources.hpp
@@ -21,6 +21,7 @@ enum class Damage_source
     slam,
     mortal_strike,
     sweeping_strikes,
+    devastate,
     size, // convenience ;)
 };
 
@@ -44,14 +45,14 @@ struct Damage_sources
     {
         return white_mh_damage + white_oh_damage + bloodthirst_damage + mortal_strike_damage + slam_damage +
                overpower_damage + heroic_strike_damage + cleave_damage + whirlwind_damage + hamstring_damage +
-               execute_damage + deep_wounds_damage + item_hit_effects_damage + sweeping_strikes_damage;
+               execute_damage + deep_wounds_damage + item_hit_effects_damage + sweeping_strikes_damage + devastate_damage;
     }
 
     [[nodiscard]] int sum_counts() const
     {
         return white_mh_count + white_oh_count + bloodthirst_count + mortal_strike_count + slam_count +
                overpower_count + heroic_strike_count + cleave_count + whirlwind_count + hamstring_count +
-               execute_count + deep_wounds_count + item_hit_effects_count + sweeping_strikes_count;
+               execute_count + deep_wounds_count + item_hit_effects_count + sweeping_strikes_count + devastate_count;
     }
 
     void add_damage(Damage_source source, double damage);
@@ -70,6 +71,7 @@ struct Damage_sources
     double hamstring_damage{};
     double deep_wounds_damage{};
     double item_hit_effects_damage{};
+    double devastate_damage{};
 
     int white_mh_count{};
     int white_oh_count{};
@@ -85,6 +87,7 @@ struct Damage_sources
     int hamstring_count{};
     int deep_wounds_count{};
     int item_hit_effects_count{};
+    int devastate_count{};
 };
 
 #endif // WOW_SIMULATOR_DAMAGE_SOURCES_HPP

--- a/simulator/source/damage_sources.cpp
+++ b/simulator/source/damage_sources.cpp
@@ -3,7 +3,7 @@
 std::ostream& operator<<(std::ostream& os, Damage_source damage_source)
 {
     static std::string m[] = {"white_mh", "white_oh", "bloodthirst", "execute", "heroic_strike", "cleave",
-                              "whirlwind", "hamstring", "deep_wound", "item_hit_effects", "overpower", "slam", "mortal_strike", "sweeping_strikes","devastate"};
+                              "whirlwind", "hamstring", "deep_wound", "item_hit_effects", "overpower", "slam", "mortal_strike", "sweeping_strikes", "devastate"};
     return os << m[static_cast<size_t>(damage_source)];
 }
 

--- a/simulator/source/damage_sources.cpp
+++ b/simulator/source/damage_sources.cpp
@@ -3,7 +3,7 @@
 std::ostream& operator<<(std::ostream& os, Damage_source damage_source)
 {
     static std::string m[] = {"white_mh", "white_oh", "bloodthirst", "execute", "heroic_strike", "cleave",
-                              "whirlwind", "hamstring", "deep_wound", "item_hit_effects", "overpower", "slam", "mortal_strike", "sweeping_strikes"};
+                              "whirlwind", "hamstring", "deep_wound", "item_hit_effects", "overpower", "slam", "mortal_strike", "sweeping_strikes","devastate"};
     return os << m[static_cast<size_t>(damage_source)];
 }
 
@@ -23,6 +23,7 @@ Damage_sources& Damage_sources::operator+(const Damage_sources& rhs)
     hamstring_damage = hamstring_damage + rhs.hamstring_damage;
     deep_wounds_damage = deep_wounds_damage + rhs.deep_wounds_damage;
     item_hit_effects_damage = item_hit_effects_damage + rhs.item_hit_effects_damage;
+    devastate_damage = devastate_damage + rhs.devastate_damage;
 
     whirlwind_count = whirlwind_count + rhs.whirlwind_count;
     overpower_count = overpower_count + rhs.overpower_count;
@@ -38,6 +39,7 @@ Damage_sources& Damage_sources::operator+(const Damage_sources& rhs)
     hamstring_count = hamstring_count + rhs.hamstring_count;
     deep_wounds_count = deep_wounds_count + rhs.deep_wounds_count;
     item_hit_effects_count = item_hit_effects_count + rhs.item_hit_effects_count;
+    devastate_count = devastate_count + rhs.devastate_count;
     return *(this);
 }
 
@@ -100,6 +102,10 @@ void Damage_sources::add_damage(Damage_source source, double damage)
     case Damage_source::item_hit_effects:
         item_hit_effects_damage += damage;
         item_hit_effects_count++;
+        break;
+    case Damage_source::devastate:
+        devastate_damage += damage;
+        devastate_count++;
         break;
     default:
         assert(false);

--- a/website/index.html
+++ b/website/index.html
@@ -4639,6 +4639,20 @@
             </div>
         </div>
 
+        <div class="hide_description" id="devastate_talent_div">
+            <input type="checkbox" id="use_devastate" checked
+                   onclick="show_div('use_devastate', 'devastate_div')">
+            <label for="use_devastate"><b> Use devastate</b></label><br>
+            <div class="description" id="devastate_div">
+                <label for="whirlwind_devastate_cooldown_thresh_dd">Devastate when whirlwind CD is above:</label>
+                <!-- devastate_whirlwind_cooldown_thresh_dd is also probably not even implemented then i guess -->
+                <input type="number" id="devastate_whirlwind_cooldown_thresh_dd" name="quantity" min="-0.1" max="10" value="0.0"
+                   step="0.1"><br>
+                <input type="checkbox" id="use_devastate_in_exec_phase">
+                <label for="use_devastate_in_exec_phase"> Use devastate in execute phase</label><br>
+            </div>
+        </div>
+
         <div class="hide_description" id="sweeping_strikes_talent_div">
             <input type="checkbox" id="use_sweeping_strikes" checked
                    onclick="show_div('use_sweeping_strikes', 'sweeping_strikes_div')">
@@ -5043,7 +5057,7 @@
         "periodic_damage_interval_dd", "periodic_damage_amount_dd", "execute_phase_percentage_dd",
         "re_queue_abilities_dd", "sunder_armor_globals_dd",
         "slam_spam_max_time_dd", "slam_latency_dd", "slam_spam_rage_dd", "slam_rage_thresh_dd", "berserking_haste_dd",
-        "full_polarity_dd", "extra_target_percentage_dd", "battle_squawk_dd", "rampage_use_thresh_dd", "ferocious_inspiration_dd", "unleashed_rage_dd", "expose_weakness_dd"];
+        "full_polarity_dd", "extra_target_percentage_dd", "battle_squawk_dd", "rampage_use_thresh_dd", "ferocious_inspiration_dd", "unleashed_rage_dd", "expose_weakness_dd","devastate_whirlwind_cooldown_thresh_dd"];
 
     let sim_options = ["faerie_fire", "exposed_armor", "curse_of_recklessness", "death_wish", "enable_blood_fury", "enable_expose_weakness",
         "enable_berserking", "enable_unleashed_rage", "recklessness", "mighty_rage_potion", "debug_on", "use_bt_in_exec_phase", "use_ww_in_exec_phase", "use_hs_in_exec_phase",
@@ -5052,7 +5066,7 @@
         "multi_target_mode", "essence_of_the_red", "periodic_damage", "can_trigger_enrage",
         "ability_queue", "first_hit_heroic_strike", "use_slam", "use_sl_in_exec_phase", "use_ms_in_exec_phase", "use_mortal_strike",
         "use_sweeping_strikes", "dont_use_hm_when_ss", "fungal_bloom", "full_polarity", "battle_squawk", "ferocious_inspiration",
-        "drums_of_battle", "haste_potion", "bloodlust", "insane_strength_potion", "heroic_potion"];
+        "drums_of_battle", "haste_potion", "bloodlust", "insane_strength_potion", "heroic_potion","use_devastate","use_devastate_in_exec_phase"];
 
     let stat_weigths = ["stat_weight_strength", "stat_weight_agility", "stat_weight_ap", "stat_weight_crit",
         "stat_weight_hit", "stat_weight_expertise", "stat_weight_haste", "stat_weight_arpen", "stat_weight_bonus_damage"];

--- a/website/index.html
+++ b/website/index.html
@@ -5056,7 +5056,7 @@
         "periodic_damage_interval_dd", "periodic_damage_amount_dd", "execute_phase_percentage_dd",
         "re_queue_abilities_dd", "sunder_armor_globals_dd",
         "slam_spam_max_time_dd", "slam_latency_dd", "slam_spam_rage_dd", "slam_rage_thresh_dd", "berserking_haste_dd",
-        "full_polarity_dd", "extra_target_percentage_dd", "battle_squawk_dd", "rampage_use_thresh_dd", "ferocious_inspiration_dd", "unleashed_rage_dd", "expose_weakness_dd","devastate_whirlwind_cooldown_thresh_dd"];
+        "full_polarity_dd", "extra_target_percentage_dd", "battle_squawk_dd", "rampage_use_thresh_dd", "ferocious_inspiration_dd", "unleashed_rage_dd", "expose_weakness_dd", "devastate_whirlwind_cooldown_thresh_dd"];
 
     let sim_options = ["faerie_fire", "exposed_armor", "curse_of_recklessness", "death_wish", "enable_blood_fury", "enable_expose_weakness",
         "enable_berserking", "enable_unleashed_rage", "recklessness", "mighty_rage_potion", "debug_on", "use_bt_in_exec_phase", "use_ww_in_exec_phase", "use_hs_in_exec_phase",
@@ -5065,7 +5065,7 @@
         "multi_target_mode", "essence_of_the_red", "periodic_damage", "can_trigger_enrage",
         "ability_queue", "first_hit_heroic_strike", "use_slam", "use_sl_in_exec_phase", "use_ms_in_exec_phase", "use_mortal_strike",
         "use_sweeping_strikes", "dont_use_hm_when_ss", "fungal_bloom", "full_polarity", "battle_squawk", "ferocious_inspiration",
-        "drums_of_battle", "haste_potion", "bloodlust", "insane_strength_potion", "heroic_potion","use_devastate","use_devastate_in_exec_phase"];
+        "drums_of_battle", "haste_potion", "bloodlust", "insane_strength_potion", "heroic_potion", "use_devastate", "use_devastate_in_exec_phase"];
 
     let stat_weigths = ["stat_weight_strength", "stat_weight_agility", "stat_weight_ap", "stat_weight_crit",
         "stat_weight_hit", "stat_weight_expertise", "stat_weight_haste", "stat_weight_arpen", "stat_weight_bonus_damage"];

--- a/website/index.html
+++ b/website/index.html
@@ -4645,7 +4645,6 @@
             <label for="use_devastate"><b> Use devastate</b></label><br>
             <div class="description" id="devastate_div">
                 <label for="whirlwind_devastate_cooldown_thresh_dd">Devastate when whirlwind CD is above:</label>
-                <!-- devastate_whirlwind_cooldown_thresh_dd is also probably not even implemented then i guess -->
                 <input type="number" id="devastate_whirlwind_cooldown_thresh_dd" name="quantity" min="-0.1" max="10" value="0.0"
                    step="0.1"><br>
                 <input type="checkbox" id="use_devastate_in_exec_phase">

--- a/website/js/talents.js
+++ b/website/js/talents.js
@@ -88,7 +88,6 @@ let not_implemented_talents = [
     "last_stand_talent",
     "improved_shield_block_talent",
     "improved_revenge_talent",
-    "improved_sunder_armor_talent",
     "improved_disarm_talent",
     "improved_taunt_talent",
     "improved_shield_wall_talent",
@@ -96,10 +95,7 @@ let not_implemented_talents = [
     "improved_shield_bash_talent",
     "shield_mastery_talent",
     "improved_defensive_stance_talent",
-    "shield_slam_talent",
-    "focused_rage_talent",
-    "vitality_talent",
-    "devastate_talent"];
+    "shield_slam_talent"];
 
 function load_talent_clear() {
     for (let i = 0; i < talents_vec.length; i++) {

--- a/website/js/talents.js
+++ b/website/js/talents.js
@@ -226,6 +226,14 @@ function showHideTalentDiv() {
         document.getElementById("mortal_strike_talent_div").style.display = "none";
     }
 
+    let devastate_talent = document.getElementById("devastate_talent");
+    current_val = parseInt(devastate_talent.getAttribute("data-count"));
+    if (current_val === 1) {
+        document.getElementById("devastate_talent_div").style.display = "block";
+    } else {
+        document.getElementById("devastate_talent_div").style.display = "none";
+    }
+
     let bt_talent = document.getElementById("bloodthirst_talent");
     current_val = parseInt(bt_talent.getAttribute("data-count"));
     if (current_val === 1) {

--- a/wow_library/include/Attributes.hpp
+++ b/wow_library/include/Attributes.hpp
@@ -17,7 +17,7 @@ struct Special_stats
                   double haste = 0, double damage_mod_physical = 0, double stat_multiplier = 0,
                   double bonus_damage = 0, double crit_multiplier = 0, double spell_crit = 0,
                   double damage_mod_spell = 0, double expertise = 0, double sword_expertise = 0, double mace_expertise = 0, double axe_expertise = 0,
-                  int gear_armor_pen = 0, double ap_multiplier = 0, double attack_speed = 0)
+                  int gear_armor_pen = 0, double ap_multiplier = 0, double attack_speed = 0, double str_multiplier = 0)
         : critical_strike{critical_strike}
         , hit{hit}
         , attack_power{attack_power}
@@ -36,6 +36,7 @@ struct Special_stats
         , gear_armor_pen{gear_armor_pen}
         , ap_multiplier{ap_multiplier}
         , attack_speed{attack_speed}
+        , str_multiplier{str_multiplier}
     {
     }
 
@@ -76,6 +77,7 @@ struct Special_stats
             gear_armor_pen + rhs.gear_armor_pen,
             multiplicative_addition(ap_multiplier, rhs.ap_multiplier),
             multiplicative_addition(attack_speed, rhs.attack_speed),
+            multiplicative_addition(str_multiplier, rhs.str_multiplier),
         };
     }
 
@@ -102,6 +104,7 @@ struct Special_stats
             gear_armor_pen - rhs.gear_armor_pen,
             multiplicative_subtraction(ap_multiplier, rhs.ap_multiplier),
             multiplicative_subtraction(attack_speed, rhs.attack_speed),
+            multiplicative_subtraction(str_multiplier, rhs.str_multiplier),
         };
     }
 
@@ -124,6 +127,7 @@ struct Special_stats
     double haste{};
     double damage_mod_physical{};
     double stat_multiplier{};
+    double str_multiplier{};
     double bonus_damage{};
     double crit_multiplier{};
     double spell_crit{};
@@ -154,13 +158,15 @@ public:
     [[nodiscard]] Attributes multiply(const Special_stats& multipliers) const
     {
         const double multiplier = multipliers.stat_multiplier + 1;
-        return {strength * multiplier, agility * multiplier};
+        const double smultiplier = multipliers.str_multiplier + 1;
+        return {strength * multiplier * smultiplier, agility * multiplier};
     }
 
     [[nodiscard]] Special_stats to_special_stats(const Special_stats& multipliers) const
     {
         const double multiplier = multipliers.stat_multiplier + 1;
-        return {agility * multiplier / 33, 0, strength * multiplier * 2};
+        const double smultiplier = multipliers.str_multiplier + 1;
+        return {agility * multiplier / 33, 0, strength * smultiplier* multiplier * 2};
     }
 
     Attributes operator+(const Attributes& rhs) const { return {strength + rhs.strength, agility + rhs.agility}; }

--- a/wow_library/include/Attributes.hpp
+++ b/wow_library/include/Attributes.hpp
@@ -127,7 +127,6 @@ struct Special_stats
     double haste{};
     double damage_mod_physical{};
     double stat_multiplier{};
-    double str_multiplier{};
     double bonus_damage{};
     double crit_multiplier{};
     double spell_crit{};
@@ -137,9 +136,9 @@ struct Special_stats
     double mace_expertise{};
     double axe_expertise{};
     int gear_armor_pen{};
-
     double ap_multiplier{};
     double attack_speed{};
+    double str_multiplier{};
 };
 
 class Attributes

--- a/wow_library/include/Character.hpp
+++ b/wow_library/include/Character.hpp
@@ -229,7 +229,7 @@ public:
         //int improved_shield_block{};
         //int improved_revenge{};
         int defiance{};
-        //int improved_sunder_armor{};
+        int improved_sunder_armor{};
         //int improved_disarm{};
         //int improved_taunt{};
         //int improved_shield_wall{};
@@ -239,9 +239,9 @@ public:
         int one_handed_weapon_specialization{};
         //int improved_defensive_stance{};
         //int shield_slam{};
-        //int focused_rage{};
-        //int vitality{};
-        //int devastate{};
+        int focused_rage{};
+        int vitality{};
+        int devastate{};
     } talents;
 
     Attributes base_attributes;

--- a/wow_library/source/Armory.cpp
+++ b/wow_library/source/Armory.cpp
@@ -349,7 +349,7 @@ void Armory::compute_total_stats(Character& character) const
     talent_special_stats.hit = character.talents.precision;
     talent_special_stats.expertise = character.talents.defiance * 2;
     talent_special_stats.ap_multiplier = character.talents.improved_berserker_stance * 0.02;
-    talent_special_stats.str_multiplier = character.talents.vitality * .02;
+    talent_special_stats.str_multiplier = character.talents.vitality * 0.02;
     if (character.is_dual_wield())
     {
         talent_special_stats.damage_mod_physical = character.talents.one_handed_weapon_specialization * 0.02;

--- a/wow_library/source/Armory.cpp
+++ b/wow_library/source/Armory.cpp
@@ -349,6 +349,7 @@ void Armory::compute_total_stats(Character& character) const
     talent_special_stats.hit = character.talents.precision;
     talent_special_stats.expertise = character.talents.defiance * 2;
     talent_special_stats.ap_multiplier = character.talents.improved_berserker_stance * 0.02;
+    talent_special_stats.str_multiplier = character.talents.vitality * .02;
     if (character.is_dual_wield())
     {
         talent_special_stats.damage_mod_physical = character.talents.one_handed_weapon_specialization * 0.02;
@@ -1351,4 +1352,8 @@ void Armory::add_talents_to_character(Character& character, const std::vector<st
     character.talents.tactical_mastery = fv.find("tactical_mastery_talent");
     character.talents.defiance = fv.find("defiance_talent");
     character.talents.one_handed_weapon_specialization = fv.find("one_handed_weapon_specialization_talent");
+    character.talents.devastate = fv.find("devastate_talent");
+    character.talents.improved_sunder_armor = fv.find("improved_sunder_armor_talent");
+    character.talents.focused_rage = fv.find("focused_rage_talent");
+    character.talents.vitality = fv.find("vitality_talent");
 }


### PR DESCRIPTION
This has an implementation for devastate as well as the relevant deep prot tree talents (imp sunder, focused rage, and vitality). I don't see any obvious issues with the way I implemented the double proc chance of devastate but it's worth a check that that isn't messing something up or counting anything twice in case I misunderstood something.